### PR TITLE
Fix gemspec

### DIFF
--- a/redis_wrapper.gemspec
+++ b/redis_wrapper.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = ""
   spec.description   = ""
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "http://www.iruby.com.cn"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
To fix the error:

Fetching git://github.com/AllBestBets/redis_wrapper.git
You have one or more invalid gemspecs that need to be fixed.
The gemspec at /home/insticore/.rvm/gems/ruby-2.3.3/bundler/gems/redis_wrapper-5bf425424885/redis_wrapper.gemspec is not
valid. Please fix this gemspec.
The validation error was '"TODO: Put your gem's website or public repo URL here." is not a valid HTTP URI'